### PR TITLE
feat: implement JSONL logger with verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ pair -p "Refactor" --navigator opencode --navigator-model openrouter/google/gemi
 - `--dir <path>`: Project directory path (default: current directory)
 - `-p, --prompt <text>`: Task prompt as text
 - `-f, --file <file>`: Load prompt from file (.txt, .md, .json, .yaml, .yml)
+- `-v, --verbose`: Enable verbose logging (logs all agent communication)
 - `--navigator <provider>`: Set navigator provider (claude-code, opencode)
 - `--navigator-model <model>`: Set navigator model
 - `--driver <provider>`: Set driver provider
@@ -142,9 +143,44 @@ When `opencode` is on your PATH, the provider will automatically launch a local 
 
 ### Debugging and Logging
 - `LOG_LEVEL`: Enable file logging (default: disabled)
+  - `error`: Log only errors
+  - `warn`: Log warnings and errors
+  - `info`: Log general information, tools usage
   - `debug`: Enable detailed session logging
+  - `verbose`: Log all agent communication data (same as using -v flag)
+- `CLAUDE_PAIR_VERBOSE`: Set to "true" to enable verbose logging (same as -v flag)
+- `-v, --verbose`: Command-line flag to enable verbose logging
 
-When enabled, logs are written to `~/.pair/logs/pair-debug.log`
+When enabled, logs are written to `~/.pair/logs/pair-debug.log` in JSONL format (one JSON object per line)
+
+#### Log Format
+The logger now uses JSONL format for easier parsing and analysis:
+- Each log entry is a single JSON object on its own line
+- Includes timestamp, event type, and relevant data
+- In verbose mode, includes full agent communication data
+- In normal mode, data is truncated to reasonable lengths
+
+Example:
+```bash
+# Enable verbose logging via CLI
+pair -v -p "Add logging"
+
+# Enable verbose logging via environment
+LOG_LEVEL=verbose pair -p "Fix bug"
+
+# View logs (each line is a JSON object)
+tail -f ~/.pair/logs/pair-debug.log | jq '.'
+```
+
+#### Log Event Types
+- `SESSION_START`: Initial log entry with session info
+- `EVENT`: General events in the application
+- `TOOL_USE`: Tool invocations by agents
+- `TOOL_RESULT`: Results from tool executions
+- `NAVIGATOR_SESSION`: Navigator agent messages (verbose mode)
+- `DRIVER_SESSION`: Driver agent messages (verbose mode)
+- `AGENT_COMMUNICATION`: Inter-agent communication (verbose mode)
+- `STATE_CHANGE`: Application state changes
 
 Example:
 ```bash

--- a/src/app.ts
+++ b/src/app.ts
@@ -75,11 +75,12 @@ export class PairApp {
 		this.config.projectPath = normalizedProjectPath;
 		this.config.initialTask = task;
 
-		this.logger = new Logger("pair-debug.log");
+		this.logger = new Logger("pair-debug.log", appConfig.verboseLogging);
 		const logPath = this.logger.getFilePath();
 		this.logger.logEvent("APP_LOGGING_CONFIG", {
-			level: process.env.LOG_LEVEL || "(disabled)",
+			level: appConfig.verboseLogging ? "verbose" : (process.env.LOG_LEVEL || "(disabled)"),
 			file: logPath || "(none)",
+			verbose: appConfig.verboseLogging,
 		});
 	}
 

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -40,6 +40,7 @@ function createProgram(): Command {
 		.option("-p, --prompt <text>", "Task prompt to implement")
 		.option("-d, --dir <path>", "Project directory", process.cwd())
 		.option("-f, --file <file>", "Read prompt from file (overrides --prompt)")
+		.option("-v, --verbose", "Enable verbose logging")
 		.option("--navigator <provider>", "Navigator provider", "claude-code")
 		.option("--navigator-model <model>", "Navigator model")
 		.option("--driver <provider>", "Driver provider", "claude-code")
@@ -69,6 +70,9 @@ export async function parseCliArgs(args: string[]): Promise<ParsedCliArgs> {
 	const options = program.opts();
 
 	// Apply CLI overrides to config
+	if (options.verbose) {
+		config.verboseLogging = true;
+	}
 	if (options.navigator) {
 		config.navigatorConfig.provider = options.navigator;
 	}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -23,6 +23,9 @@ export interface AppConfig {
 	/** Enable sync status updates in footer (default: true) */
 	enableSyncStatus: boolean;
 
+	/** Enable verbose logging for agent communication (default: false) */
+	verboseLogging: boolean;
+
 	/** Model configuration for navigator agent */
 	navigatorConfig: ModelConfig;
 
@@ -37,6 +40,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 	maxPromptFileSize: 100 * 1024, // 100KB
 	sessionHardLimitMs: 30 * 60 * 1000, // 30 minutes
 	enableSyncStatus: true, // Enable by default
+	verboseLogging: false, // Disable by default
 	navigatorConfig: {
 		provider: "claude-code",
 		model: "claude-opus-4-1-20250805", // Opus 4.1 for both planning and monitoring
@@ -70,6 +74,7 @@ export function loadConfig(): AppConfig {
 			60 *
 			1000,
 		enableSyncStatus: process.env.CLAUDE_PAIR_DISABLE_SYNC_STATUS !== "true",
+		verboseLogging: process.env.CLAUDE_PAIR_VERBOSE === "true",
 		navigatorConfig: { ...DEFAULT_CONFIG.navigatorConfig },
 		driverConfig: { ...DEFAULT_CONFIG.driverConfig },
 	};

--- a/src/utils/eventHandlers.ts
+++ b/src/utils/eventHandlers.ts
@@ -24,6 +24,7 @@ export class EventHandlersManager {
 		// Planning navigator events
 		this.planningNavigator.on("message", (message) => {
 			this.display.showPlanningTurn(message.content);
+			this.logger.logAgentCommunication("navigator-planning", "display", "message", message);
 		});
 
 		this.planningNavigator.on("tool_use", ({ tool, input }) => {
@@ -37,6 +38,7 @@ export class EventHandlersManager {
 				return;
 			}
 			this.display.showNavigatorTurn(message.content);
+			this.logger.logAgentCommunication("navigator-monitoring", "display", "message", message);
 		});
 
 		this.monitoringNavigator.on("tool_use", ({ tool, input }) => {
@@ -47,6 +49,7 @@ export class EventHandlersManager {
 		// Driver events
 		this.driver.on("message", (message) => {
 			this.display.showDriverTurn(message.content);
+			this.logger.logAgentCommunication("driver", "display", "message", message);
 			// Buffer for permission bulk-forwarding
 			const t = (message.content || "").trim();
 			if (t) this.addToDriverBuffer(t);

--- a/src/utils/permissionHandler.ts
+++ b/src/utils/permissionHandler.ts
@@ -32,9 +32,11 @@ export class PermissionHandler {
 		const { controller, cleanup } = createTimeout(timeoutMs);
 
 		try {
+			this.logger.logAgentCommunication("driver", "navigator", "permission_request", request);
 			const result = await this.navigator.reviewPermission(request, {
 				signal: controller.signal,
 			});
+			this.logger.logAgentCommunication("navigator", "driver", "permission_result", result);
 			cleanup();
 			return result;
 		} catch (error) {


### PR DESCRIPTION
Closes #17

## Summary
Implemented a more concise JSONL logger with verbose mode for agent communication data.

## Changes
- Convert logger to JSONL format (one JSON object per line)
- Add verbose mode for logging all agent communication data
- Add -v/--verbose CLI flag
- Support LOG_LEVEL=verbose and CLAUDE_PAIR_VERBOSE=true env vars
- Log agent messages, tool usage, and inter-agent communication in verbose mode
- Update documentation with logging details

Generated with [Claude Code](https://claude.ai/code)